### PR TITLE
allow for customizing FootNoteSectionHeading level

### DIFF
--- a/src/insert-or-navigate-footnotes.ts
+++ b/src/insert-or-navigate-footnotes.ts
@@ -164,7 +164,14 @@ export function addFootnoteSectionHeader(
     // else, return ""
 
     if (plugin.settings.enableFootnoteSectionHeading == true) {
-        let returnHeading = `\n# ${plugin.settings.FootnoteSectionHeading}`;
+
+        let returnHeading = plugin.settings.FootnoteSectionHeading;
+        const headingRegex = /^\#{1,6} /;
+        if (headingRegex.test(returnHeading)) {
+            returnHeading = `\n${returnHeading}`;
+        } else {
+            returnHeading = `\n# ${returnHeading}`;
+        }
         return returnHeading;
     }
     return "";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,7 +73,7 @@ export class FootnotePluginSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
         .setName("Footnote Section Heading")
-        .setDesc("Heading to place above footnotes section (Supports Markdown formatting). Heading will be H1 size.")
+        .setDesc("Heading to place above footnotes section (Supports Markdown formatting). Heading will be H1 size, unless overridden.")
         .addText((text) =>
             text
                 .setPlaceholder("Heading is Empty")


### PR DESCRIPTION
If the user specifies a section heading string that starts with a properly formatted heading level it will be used instead of the default H1. Resolves #27.